### PR TITLE
Refactor/position types

### DIFF
--- a/ramanujan/cmf.py
+++ b/ramanujan/cmf.py
@@ -5,6 +5,18 @@ from ramanujan import Matrix, Position, simplify
 
 
 class CMF:
+    variables = [x, y]
+
+    @staticmethod
+    def _initialize_positions(*positions):
+        return (CMF._initialize_position(position) for position in positions)
+
+    @staticmethod
+    def _initialize_position(position):
+        if type(position) == list:
+            return dict(zip(CMF.variables, position))
+        return position
+
     def __init__(self, Mx: Matrix, My: Matrix):
         self.m_Mx = Mx
         self.m_My = My
@@ -30,8 +42,9 @@ class CMF:
 
         If start is given, the new matrix will be reduces to a single variable `n`.
         """
-        m = self.m_Mx.walk({x: 1, y: 0}, trajectory[0], {x: x, y: y})
-        m *= self.m_My.walk({x: 0, y: 1}, trajectory[1], {x: x + trajectory[0], y: y})
+        start, trajectory = CMF._initialize_positions(start, trajectory)
+        m = self.m_Mx.walk({x: 1, y: 0}, trajectory[x], {x: x, y: y})
+        m *= self.m_My.walk({x: 0, y: 1}, trajectory[y], {x: x + trajectory[x], y: y})
         if start is not None:
             m = CMF.substitute_trajectory(m, trajectory, start)
         return simplify(m)
@@ -41,8 +54,9 @@ class CMF:
         """Returns trajectory_matrix reduced to a single variable `n`."""
         from sympy.abc import n
 
+        start, trajectory = CMF._initialize_positions(start, trajectory)
         sub = lambda i: start[i] + (n - 1) * trajectory[i]
-        return trajectory_matrix.subs([(x, sub(0)), (y, sub(1))])
+        return trajectory_matrix.subs([(x, sub(x)), (y, sub(y))])
 
     def walk(self, trajectory, iterations, start=[1, 1]) -> Matrix:
         """Returns the multiplication matrix of walking in a certain trajectory."""

--- a/ramanujan/cmf.py
+++ b/ramanujan/cmf.py
@@ -13,13 +13,13 @@ class CMF:
         if simplify(Mxy - Myx) != Matrix([[0, 0], [0, 0]]):
             raise ValueError("The given Mx and My matrices are not conserving!")
 
-    def Mx(self, x, y) -> Matrix:
+    def Mx(self, _x, _y) -> Matrix:
         """Substitute Mx."""
-        return self.m_Mx(x, y)
+        return self.m_Mx.subs({x: _x, y: _y})
 
-    def My(self, x, y) -> Matrix:
+    def My(self, _x, _y) -> Matrix:
         """Substitute My."""
-        return self.m_My(x, y)
+        return self.m_My.subs({x: _x, y: _y})
 
     def subs(self, substitutions):
         """Returns a new CMF with substituted Mx and My."""

--- a/ramanujan/cmf_test.py
+++ b/ramanujan/cmf_test.py
@@ -62,7 +62,7 @@ def test_substitute_trajectory_diagonal():
     )
 
 
-def test_substitue_trajectory_walk_equivalence():
+def test_substitute_trajectory_walk_equivalence():
     cmf = known_cmfs.e
     iterations = 7
     trajectory = [1, 1]

--- a/ramanujan/matrix.py
+++ b/ramanujan/matrix.py
@@ -22,17 +22,9 @@ class Position(dict):
 
 
 class Matrix(sp.Matrix):
-    variables = {1: [n], 2: [x, y]}
-
-    def __call__(self, *args):
-        """
-        Quick substitution method.
-
-        For 1 args, assumes variable is n.
-        For 2 args, assumes variables are (x, y).
-        """
-        args = list(args)
-        return self.subs(list(zip(Matrix.variables[len(args)], args)))
+    def __call__(self, substitutions):
+        """Same as 'subs', but in a math-like syntax."""
+        return self.subs(substitutions)
 
     def gcd(self):
         """Returns gcd of the matrix"""
@@ -66,7 +58,7 @@ class Matrix(sp.Matrix):
 
         U = Matrix([[self[1, 0], -self[0, 0]], [0, 1]])
         Uinv = Matrix([[1, self[0, 0]], [0, self[1, 0]]])
-        commutated = U * self * Uinv(n + 1)
+        commutated = U * self * Uinv({n: n + 1})
         normalized = simplify(commutated / commutated[1, 0])
         pcf = PCF.from_matrix(normalized).inflate(self[1, 0])
         if deflate_all:

--- a/ramanujan/matrix_test.py
+++ b/ramanujan/matrix_test.py
@@ -28,21 +28,6 @@ def test_gcd_reduce():
     assert m.reduce() == initial
 
 
-def test_call_1():
-    m = Matrix([[x + 1, 2 * x], [x**2, 7 * x - 13]])
-    assert m(0, y) == Matrix([[1, 0], [0, -13]])
-    assert m(5, y) == Matrix([[6, 10], [25, 22]])
-    assert m(x, y) == m(x, y + 1)
-
-
-def test_call_2():
-    m = Matrix([[y + 1, 2 * x * y], [x**2, 7 * x + y]])
-    assert m(0, 0) == Matrix([[1, 0], [0, 0]])
-    assert m(5, 7) == Matrix([[8, 70], [25, 42]])
-    assert m(x, 1) == Matrix([[2, 2 * x], [x**2, 7 * x + 1]])
-    assert m(1, y) == Matrix([[y + 1, 2 * y], [1, 7 + y]])
-
-
 def test_walk_0():
     m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
     assert m.walk({x: 0, y: 1}, 0, {x: x, y: y}) == Matrix.eye(2)
@@ -50,33 +35,37 @@ def test_walk_0():
 
 def test_walk_1():
     m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
-    assert m.walk({x: 1, y: 0}, 1, {x: x, y: y}) == m(x, y)
+    assert m.walk({x: 1, y: 0}, 1, {x: x, y: y}) == m
 
 
 def test_walk_axis():
     m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
     assert simplify(m.walk({x: 1, y: 0}, 3, {x: 1, y: 1})) == simplify(
-        m(1, 1) * m(2, 1) * m(3, 1)
+        m({x: 1, y: 1}) * m({x: 2, y: 1}) * m({x: 3, y: 1})
     )
     assert simplify(m.walk({x: 0, y: 1}, 5, {x: 1, y: 1})) == simplify(
-        m(1, 1) * m(1, 2) * m(1, 3) * m(1, 4) * m(1, 5)
+        m({x: 1, y: 1})
+        * m({x: 1, y: 2})
+        * m({x: 1, y: 3})
+        * m({x: 1, y: 4})
+        * m({x: 1, y: 5})
     )
 
 
 def test_walk_diagonal():
     m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
     assert simplify(m.walk({x: 1, y: 1}, 4, {x: 1, y: 1})) == simplify(
-        m(1, 1) * m(2, 2) * m(3, 3) * m(4, 4)
+        m({x: 1, y: 1}) * m({x: 2, y: 2}) * m({x: 3, y: 3}) * m({x: 4, y: 4})
     )
     assert simplify(m.walk({x: 3, y: 2}, 3, {x: 1, y: 1})) == simplify(
-        m(1, 1) * m(4, 3) * m(7, 5)
+        m({x: 1, y: 1}) * m({x: 4, y: 3}) * m({x: 7, y: 5})
     )
 
 
 def test_walk_different_start():
     m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
     assert simplify(m.walk({x: 3, y: 2}, 3, {x: 5, y: 7})) == simplify(
-        m(5, 7) * m(8, 9) * m(11, 11)
+        m({x: 5, y: 7}) * m({x: 8, y: 9}) * m({x: 11, y: 11})
     )
 
 


### PR DESCRIPTION
Allow users to give to trajectorial functions both dicts and positional list input arguments in `CMF`.