### PR TITLE
Use CoboundarySolver for CMF

### DIFF
--- a/ramanujan/cmf/coboundary_test.py
+++ b/ramanujan/cmf/coboundary_test.py
@@ -39,12 +39,24 @@ def test_self_coboundary(matrix: Matrix):
 
 
 @pytest.mark.parametrize("cmf", known_cmf_list)
-def test_cmf_coboundary(cmf: CMF):
+def test_2_lines_cmf_coboundary(cmf: CMF):
+    # coboundary random two lines in a given cmf
     line = random.randint(1, 10)
     verify_solution(
         mx1=cmf.Mx({y: line}), mx2=cmf.Mx({y: line+1}),
         solution=cmf.My({y: line}),
         deg=5)
+
+
+@pytest.mark.parametrize("cmf", known_cmf_list)
+def test_cmf_coboundary(cmf: CMF):
+    r"""
+    Given a family of parametrized matrices, we can find if they are part of a cmf
+    """
+    verify_solution(
+        mx1=cmf.Mx, mx2=cmf.Mx({y: y+1}),
+        solution=cmf.My,
+        deg=6)
 
 
 def test_specific_coboundary():


### PR DESCRIPTION
Add a test to CoboundarySolver that checks that it works for parametrized family as well, and in particular can be used to find CMFs.