### PR TITLE
Feature/multi dimensional cmf

### DIFF
--- a/ramanujan/cmf/cmf.py
+++ b/ramanujan/cmf/cmf.py
@@ -1,6 +1,7 @@
+import sympy as sp
 from sympy.abc import n, x, y
 
-from typing import List, Collection
+from typing import List, Collection, Dict
 from multimethod import multimethod
 
 from ramanujan import Matrix, simplify, zero
@@ -15,14 +16,14 @@ class CMF:
     $Mx(x, y) \cdot My(x+1, y) = My(x, y) \cdot Mx(x, y+1)$
     """
 
-    def __init__(self, Mx: Matrix, My: Matrix):
+    def __init__(self, matrices: Dict[sp.Symbol, Matrix]):
         """
         Initializes a CMF with `Mx` and `My` matrices
         """
 
-        self.Mx = Mx
+        self.Mx = matrices[x]
         """The Mx matrix of the CMF"""
-        self.My = My
+        self.My = matrices[y]
         """The My matrix of the CMF"""
 
         Mxy = simplify(self.Mx * self.My({x: x + 1}))
@@ -38,7 +39,12 @@ class CMF:
 
     def subs(self, *args, **kwrags):
         """Returns a new CMF with substituted Mx and My."""
-        return CMF(self.Mx.subs(*args, **kwrags), self.My.subs(*args, **kwrags))
+        return CMF(
+            matrices={
+                x: self.Mx.subs(*args, **kwrags),
+                y: self.My.subs(*args, **kwrags),
+            }
+        )
 
     def simplify(self):
         """Returns a new CMF with simplified Mx and My"""

--- a/ramanujan/cmf/cmf.py
+++ b/ramanujan/cmf/cmf.py
@@ -120,7 +120,6 @@ class CMF:
         position = {axis: axis for axis in self.axes()}
         m = sp.eye(2)
         for axis in self.axes():
-            print(axis)
             m *= self.M(axis).walk(self.axis_vector(axis), trajectory[axis], position)
             position[axis] += trajectory[axis]
         if start:

--- a/ramanujan/cmf/cmf_test.py
+++ b/ramanujan/cmf/cmf_test.py
@@ -11,7 +11,7 @@ DEFAULT_START = {x: x, y: y}
 def test_non_conserving_throws():
     m = Matrix([[x, x + 17], [y * x, y * 3 - x + 5]])
     with raises(ValueError):
-        CMF(m, m)
+        CMF(matrices={x: m, y: m})
 
 
 def test_trajectory_matrix_axis():

--- a/ramanujan/cmf/cmf_test.py
+++ b/ramanujan/cmf/cmf_test.py
@@ -5,28 +5,36 @@ from ramanujan import Matrix, simplify
 from ramanujan.cmf import CMF, known_cmfs
 
 
-DEFAULT_START = {x: x, y: y}
-
-
 def test_non_conserving_throws():
     m = Matrix([[x, x + 17], [y * x, y * 3 - x + 5]])
     with raises(ValueError):
         CMF(matrices={x: m, y: m})
 
 
+def test_symbols():
+    cmf = known_cmfs.cmf1()
+    expected_axes = {x, y}
+    expected_parameters = {known_cmfs.c0, known_cmfs.c1, known_cmfs.c2, known_cmfs.c3}
+    assert expected_axes == cmf.axes()
+    assert expected_parameters == cmf.parameters()
+    assert set().union(expected_axes, expected_parameters) == cmf.free_symbols()
+
+
 def test_trajectory_matrix_axis():
     cmf = known_cmfs.e()
     assert cmf.trajectory_matrix({x: 3, y: 0}) == simplify(
-        cmf.Mx.walk({x: 1, y: 0}, 3, DEFAULT_START)
+        cmf.M(x).walk({x: 1, y: 0}, 3, {x: x, y: y})
     )
     assert cmf.trajectory_matrix({x: 0, y: 2}) == simplify(
-        cmf.My.walk({x: 0, y: 1}, 2, DEFAULT_START)
+        cmf.M(y).walk({x: 0, y: 1}, 2, {x: x, y: y})
     )
 
 
 def test_trajectory_matrix_diagonal():
     cmf = known_cmfs.e()
-    assert cmf.trajectory_matrix({x: 1, y: 1}) == simplify(cmf.Mx * cmf.My({x: x + 1}))
+    assert cmf.trajectory_matrix({x: 1, y: 1}) == simplify(
+        cmf.M(x) * cmf.M(y)({x: x + 1})
+    )
 
 
 def test_trajectory_matrix_diagonal_substitute():
@@ -40,8 +48,8 @@ def test_trajectory_matrix_diagonal_substitute():
 
 def test_walk_axis():
     cmf = known_cmfs.e()
-    assert cmf.walk({x: 1, y: 0}, 17) == cmf.Mx.walk({x: 1, y: 0}, 17, {x: 1, y: 1})
-    assert cmf.walk({x: 0, y: 1}, 17) == cmf.My.walk({x: 0, y: 1}, 17, {x: 1, y: 1})
+    assert cmf.walk({x: 1, y: 0}, 17) == cmf.M(x).walk({x: 1, y: 0}, 17, {x: 1, y: 1})
+    assert cmf.walk({x: 0, y: 1}, 17) == cmf.M(y).walk({x: 0, y: 1}, 17, {x: 1, y: 1})
 
 
 def test_walk_diagonal():
@@ -70,10 +78,10 @@ def test_limit_list():
 
 def test_substitute_trajectory_axis():
     cmf = known_cmfs.e()
-    assert CMF.substitute_trajectory(cmf.Mx, {x: 1, y: 0}, {x: 1, y: 0}) == cmf.Mx(
+    assert CMF.substitute_trajectory(cmf.M(x), {x: 1, y: 0}, {x: 1, y: 0}) == cmf.M(x)(
         {x: n, y: 0}
     )
-    assert CMF.substitute_trajectory(cmf.My, {x: 0, y: 1}, {x: 0, y: 1}) == cmf.My(
+    assert CMF.substitute_trajectory(cmf.M(y), {x: 0, y: 1}, {x: 0, y: 1}) == cmf.M(y)(
         {x: 0, y: n}
     )
 

--- a/ramanujan/cmf/coboundary.py
+++ b/ramanujan/cmf/coboundary.py
@@ -16,7 +16,9 @@ class CoboundarySolver:
     """
 
     @staticmethod
-    def solve_polynomial_matrix(matrix: Matrix, symbol: Symbol, variables: List[Symbol]) -> Dict:
+    def solve_polynomial_matrix(
+        matrix: Matrix, symbol: Symbol, variables: List[Symbol]
+    ) -> Dict:
         r"""
         Given a polynomial matrix in symbol, such that the coefficients are over 'variables',
         try to find an assignment for this variables so that matrix(assignment) == 0.
@@ -26,16 +28,18 @@ class CoboundarySolver:
         """
         # TODO 1 : move this method to a more general location, so other places can use it, also
         # TODO 2 : consider polynomial matrices in several variables as well
-        equations = \
-            Poly(matrix[0, 0], symbol).all_coeffs() + \
-            Poly(matrix[1, 0], symbol).all_coeffs() + \
-            Poly(matrix[0, 1], symbol).all_coeffs() + \
-            Poly(matrix[1, 1], symbol).all_coeffs()
+        equations = (
+            Poly(matrix[0, 0], symbol).all_coeffs()
+            + Poly(matrix[1, 0], symbol).all_coeffs()
+            + Poly(matrix[0, 1], symbol).all_coeffs()
+            + Poly(matrix[1, 1], symbol).all_coeffs()
+        )
         return sympy.solve(equations, variables)
 
     @staticmethod
     def find_coboundary(
-            m1: Matrix, m2: Matrix, max_deg: int, symbol: Symbol = x) -> Optional[Tuple[Matrix, List[Symbol]]]:
+        m1: Matrix, m2: Matrix, max_deg: int, symbol: Symbol = x
+    ) -> Optional[Tuple[Matrix, List[Symbol]]]:
         r"""
         Given two parametrized matrices $m_1(s), m_2(s)$ over the given symbol,
         look for a parametrized polynomial matrix m(s) such that
@@ -50,10 +54,10 @@ class CoboundarySolver:
         Note 2: Will probably not work if $m_1$ or $m_2$ depend on a variable different from the given symbol.
         """
 
-        f11, f11_ = GenericPolynomial.of_degree(max_deg, 'f11_', symbol)
-        f12, f12_ = GenericPolynomial.of_degree(max_deg, 'f12_', symbol)
-        f21, f21_ = GenericPolynomial.of_degree(max_deg, 'f21_', symbol)
-        f22, f22_ = GenericPolynomial.of_degree(max_deg, 'f22_', symbol)
+        f11, f11_ = GenericPolynomial.of_degree(max_deg, "f11_", symbol)
+        f12, f12_ = GenericPolynomial.of_degree(max_deg, "f12_", symbol)
+        f21, f21_ = GenericPolynomial.of_degree(max_deg, "f21_", symbol)
+        f22, f22_ = GenericPolynomial.of_degree(max_deg, "f22_", symbol)
         all_vars = f11_ + f12_ + f21_ + f22_
 
         # use '.expr' instead of just the polynomials, because calling subs(x,x+1) on polynomials in sympy
@@ -62,7 +66,9 @@ class CoboundarySolver:
         generic_m = Matrix([[f11.expr, f12.expr], [f21.expr, f22.expr]])
 
         equations = simplify(m1 * generic_m({symbol: symbol + 1}) - generic_m * m2)
-        assignment = CoboundarySolver.solve_polynomial_matrix(equations, symbol, all_vars)
+        assignment = CoboundarySolver.solve_polynomial_matrix(
+            equations, symbol, all_vars
+        )
 
         if len(assignment) == 0:
             return None
@@ -73,7 +79,9 @@ class CoboundarySolver:
         return m, vars_left
 
     @staticmethod
-    def check_unique_solution(matrix: Matrix, variables: List[Symbol]) -> Tuple[Matrix, List[Symbol]]:
+    def check_unique_solution(
+        matrix: Matrix, variables: List[Symbol]
+    ) -> Tuple[Matrix, List[Symbol]]:
         r"""
         Assuming matrix is linearly dependent on the given variables, in case there is only 1 variable v in vars,
         check if matrix = v*matrix' and if so return (matrix', []).
@@ -81,7 +89,9 @@ class CoboundarySolver:
         """
         if len(variables) == 1:
             v = variables[0]
-            if matrix.subs({v: 0}) == Matrix([[0, 0], [0, 0]]):  # the matrix m is linear in the variables
+            if matrix.subs({v: 0}) == Matrix(
+                [[0, 0], [0, 0]]
+            ):  # the matrix m is linear in the variables
                 return matrix.subs({v: 1}), []
 
         return matrix, variables

--- a/ramanujan/cmf/coboundary_test.py
+++ b/ramanujan/cmf/coboundary_test.py
@@ -23,19 +23,31 @@ def verify_solution(mx1: Matrix, mx2: Matrix, solution: Matrix, deg: int):
 
     mm, variables = result
     # Check that the given solution appears in the vector space of solutions 'mm'
-    assignment = CoboundarySolver.solve_polynomial_matrix(mm - solution, symbol=x, variables=variables)
+    assignment = CoboundarySolver.solve_polynomial_matrix(
+        mm - solution, symbol=x, variables=variables
+    )
     assert len(assignment) > 0
 
 
-@pytest.mark.parametrize("matrix", [Matrix([[1, x], [x**2, x+5]]), Matrix([[1+x+x**2, x], [x**5, x+5+x**3]])])
+@pytest.mark.parametrize(
+    "matrix",
+    [
+        Matrix([[1, x], [x**2, x + 5]]),
+        Matrix([[1 + x + x**2, x], [x**5, x + 5 + x**3]]),
+    ],
+)
 def test_self_coboundary(matrix: Matrix):
     """
     Every matrix is coboundary equivalent to itself via the identity matrix.
     """
     verify_solution(
-        mx1=matrix, mx2=matrix,
-        solution=Matrix([[1, 0], [0, 1]]),  # TODO : create Matrix.ID2() method which returns a 2x2 identity matrix
-        deg=1)
+        mx1=matrix,
+        mx2=matrix,
+        solution=Matrix(
+            [[1, 0], [0, 1]]
+        ),  # TODO : create Matrix.ID2() method which returns a 2x2 identity matrix
+        deg=1,
+    )
 
 
 @pytest.mark.parametrize("cmf", known_cmf_list)
@@ -43,9 +55,11 @@ def test_2_lines_cmf_coboundary(cmf: CMF):
     # coboundary random two lines in a given cmf
     line = random.randint(1, 10)
     verify_solution(
-        mx1=cmf.Mx({y: line}), mx2=cmf.Mx({y: line+1}),
-        solution=cmf.My({y: line}),
-        deg=5)
+        mx1=cmf.M(x)({y: line}),
+        mx2=cmf.M(x)({y: line + 1}),
+        solution=cmf.M(y)({y: line}),
+        deg=5,
+    )
 
 
 @pytest.mark.parametrize("cmf", known_cmf_list)
@@ -53,18 +67,17 @@ def test_cmf_coboundary(cmf: CMF):
     r"""
     Given a family of parametrized matrices, we can find if they are part of a cmf
     """
-    verify_solution(
-        mx1=cmf.Mx, mx2=cmf.Mx({y: y+1}),
-        solution=cmf.My,
-        deg=6)
+    verify_solution(mx1=cmf.M(x), mx2=cmf.M(x)({y: y + 1}), solution=cmf.M(y), deg=6)
 
 
 def test_specific_coboundary():
-    mx1 = Matrix([[0, -x**8], [1, x**4 + (1+x)**4]])
-    mx2 = Matrix([[0, -x**8], [1, x**4 + (1+x)**4 + 2*(x**2 + (1+x)**2)]])
-    solution = Matrix([[x**4 * (1-2*x), -x**8 * (1+2*x)],
-                       [2*x-1,          x**4 * (1+2*x)]])
+    mx1 = Matrix([[0, -(x**8)], [1, x**4 + (1 + x) ** 4]])
+    mx2 = Matrix([[0, -(x**8)], [1, x**4 + (1 + x) ** 4 + 2 * (x**2 + (1 + x) ** 2)]])
+    solution = Matrix(
+        [[x**4 * (1 - 2 * x), -(x**8) * (1 + 2 * x)], [2 * x - 1, x**4 * (1 + 2 * x)]]
+    )
 
     verify_solution(mx1=mx1, mx2=mx2, solution=solution, deg=10)
+
 
 # TODO: Add negative tests, for matrices which are not polynomially coboundary equivalent

--- a/ramanujan/cmf/ffbar/ffbar.py
+++ b/ramanujan/cmf/ffbar/ffbar.py
@@ -7,7 +7,7 @@ from ramanujan.cmf import CMF
 
 class FFbar(CMF):
     r"""
-    Represents a Conservative Matrix Field that was generated using the f, fbar construction:
+    Represents a 2D Conservative Matrix Field that was generated using the f, fbar construction:
     $a(x, y) = f(x, y) - \bar{f}(x+1, y) = f(x+1, y-1) - \bar{f}(x, y-1)$,
     $b(x) = f\bar{f}(x, 0) - f\bar{f}(0, 0) = f\bar{f}(x, y) - f\bar{f}(0, y)$,
 

--- a/ramanujan/cmf/ffbar/ffbar.py
+++ b/ramanujan/cmf/ffbar/ffbar.py
@@ -68,8 +68,10 @@ class FFbar(CMF):
         """The fbar function of the FFbar CMF"""
 
         super().__init__(
-            Matrix([[0, self.b()], [1, self.a()]]),
-            Matrix([[self.fbar, self.b()], [1, self.f]]),
+            matrices={
+                x: Matrix([[0, self.b()], [1, self.a()]]),
+                y: Matrix([[self.fbar, self.b()], [1, self.f]]),
+            }
         )
 
     def __repr__(self):

--- a/ramanujan/cmf/ffbar/ffbar_test.py
+++ b/ramanujan/cmf/ffbar/ffbar_test.py
@@ -19,16 +19,18 @@ def test_quadratic_condition():
 def test_ffbar_construction():
     c0, c1, c2,
     assert known_cmfs.cmf1() == CMF(
-        Matrix(
-            [
-                [0, -c0 * c2 + (c0 + c1 * x) * (c2 + c3 * x)],
-                [1, c0 + c1 * (x + y) - c2 - c3 * (x - y + 1)],
-            ]
-        ),
-        Matrix(
-            [
-                [c2 + c3 * (x - y), -c0 * c2 + (c0 + c1 * x) * (c2 + c3 * x)],
-                [1, c0 + c1 * (x + y)],
-            ]
-        ),
+        matrices={
+            x: Matrix(
+                [
+                    [0, -c0 * c2 + (c0 + c1 * x) * (c2 + c3 * x)],
+                    [1, c0 + c1 * (x + y) - c2 - c3 * (x - y + 1)],
+                ]
+            ),
+            y: Matrix(
+                [
+                    [c2 + c3 * (x - y), -c0 * c2 + (c0 + c1 * x) * (c2 + c3 * x)],
+                    [1, c0 + c1 * (x + y)],
+                ]
+            ),
+        }
     )

--- a/ramanujan/cmf/known_cmfs/__init__.py
+++ b/ramanujan/cmf/known_cmfs/__init__.py
@@ -1,4 +1,18 @@
-from .known_cmfs import c0, c1, c2, c3, e, pi, zeta3, cmf1, cmf2, cmf3_1, cmf3_2, cmf3_3
+from .known_cmfs import (
+    c0,
+    c1,
+    c2,
+    c3,
+    e,
+    pi,
+    zeta3,
+    cmf1,
+    cmf2,
+    cmf3_1,
+    cmf3_2,
+    cmf3_3,
+    hypergeometric_derived_3d,
+)
 
 __all__ = [
     "c0",
@@ -13,4 +27,5 @@ __all__ = [
     "cmf3_1",
     "cmf3_2",
     "cmf3_3",
+    "hypergeometric_derived_3d",
 ]

--- a/ramanujan/cmf/known_cmfs/known_cmfs.py
+++ b/ramanujan/cmf/known_cmfs/known_cmfs.py
@@ -10,31 +10,38 @@ c0, c1, c2, c3 = sp.symbols("c:4")
 
 def e():
     return CMF(
-        Matrix([[1, -y - 1], [-1, x + y + 2]]), Matrix([[0, -y - 1], [-1, x + y + 1]])
+        matrices={
+            x: Matrix([[1, -y - 1], [-1, x + y + 2]]),
+            y: Matrix([[0, -y - 1], [-1, x + y + 1]]),
+        }
     )
 
 
 def pi():
     return CMF(
-        Matrix([[x, -x], [-y, 2 * x + y + 1]]),
-        Matrix([[1 + y, -x], [-1 - y, x + 2 * y + 1]]),
+        matrices={
+            x: Matrix([[x, -x], [-y, 2 * x + y + 1]]),
+            y: Matrix([[1 + y, -x], [-1 - y, x + 2 * y + 1]]),
+        }
     )
 
 
 def zeta3():
     return CMF(
-        Matrix(
-            [
-                [0, -(x**3)],
-                [(x + 1) ** 3, x**3 + (x + 1) ** 3 + 2 * y * (y - 1) * (2 * x + 1)],
-            ]
-        ),
-        Matrix(
-            [
-                [-(x**3) + 2 * x**2 * y - 2 * x * y**2 + y**3, -(x**3)],
-                [x**3, x**3 + 2 * x**2 * y + 2 * x * y**2 + y**3],
-            ]
-        ),
+        matrices={
+            x: Matrix(
+                [
+                    [0, -(x**3)],
+                    [(x + 1) ** 3, x**3 + (x + 1) ** 3 + 2 * y * (y - 1) * (2 * x + 1)],
+                ]
+            ),
+            y: Matrix(
+                [
+                    [-(x**3) + 2 * x**2 * y - 2 * x * y**2 + y**3, -(x**3)],
+                    [x**3, x**3 + 2 * x**2 * y + 2 * x * y**2 + y**3],
+                ]
+            ),
+        }
     )
 
 
@@ -48,40 +55,41 @@ def var_root_cmf():
     a = (2 * x + c1 + 1) * (2 * x + c0 + 1) - x * (x + 1)
     F = x**2 + x * (Y + 1) + (Y + 1 - c1) * (Y + 1 - c0)
     G = -(Y + 2 * x) * (x + c1 + c0 - (Y + 1))
-    return CMF(Mx=Matrix([[0, b], [1, a]]), My=Matrix([[G, b], [1, F]]))
+    return CMF(matrices={x: Matrix([[0, b], [1, a]]), y: Matrix([[G, b], [1, F]])})
 
 
 def cmf1():
-    return FFbar(c0 + c1 * (x + y), c2 + c3 * (x - y))
+    return FFbar(f=c0 + c1 * (x + y), fbar=c2 + c3 * (x - y))
 
 
 def cmf2():
     return FFbar(
-        (2 * c1 + c2) * (c1 + c2)
-        - c3 * c0
-        - c3 * ((2 * c1 + c2) * (x + y) + (c1 + c2) * (2 * x + y))
-        + c3**2 * (2 * x**2 + 2 * x * y + y**2),
-        c3 * (c0 + c2 * x + c1 * y) - c3**2 * (2 * x**2 - 2 * x * y + y**2),
+        f=(
+            (2 * c1 + c2) * (c1 + c2)
+            - c3 * c0
+            - c3 * ((2 * c1 + c2) * (x + y) + (c1 + c2) * (2 * x + y))
+            + c3**2 * (2 * x**2 + 2 * x * y + y**2)
+        ),
+        fbar=c3 * (c0 + c2 * x + c1 * y) - c3**2 * (2 * x**2 - 2 * x * y + y**2),
     )
 
 
 def cmf3_1():
     return FFbar(
-        -((c0 + c1 * (x + y)) * (c0 * (x + 2 * y) + c1 * (x**2 + x * y + y**2))),
-        (c0 + c1 * (-x + y)) * (c0 * (x - 2 * y) - c1 * (x**2 - x * y + y**2)),
+        f=-((c0 + c1 * (x + y)) * (c0 * (x + 2 * y) + c1 * (x**2 + x * y + y**2))),
+        fbar=(c0 + c1 * (-x + y)) * (c0 * (x - 2 * y) - c1 * (x**2 - x * y + y**2)),
     )
 
 
 def cmf3_2():
     return FFbar(
-        -(x + y) * (c0**2 + 2 * c1**2 * (x**2 + x * y + y**2)),
-        (x - y) * (c0**2 + 2 * c1**2 * (x**2 - x * y + y**2)),
+        f=-(x + y) * (c0**2 + 2 * c1**2 * (x**2 + x * y + y**2)),
+        fbar=(x - y) * (c0**2 + 2 * c1**2 * (x**2 - x * y + y**2)),
     )
 
 
 def cmf3_3():
     return FFbar(
-        (x + y)
-        * (c0**2 - c0 * c1 * (x - y) - 2 * c1**2 * (x**2 + x * y + y**2)),
-        (c0 + c1 * (x - y)) * (3 * c0 * (x - y) + 2 * c1 * (x**2 - x * y + y**2)),
+        f=(x + y) * (c0**2 - c0 * c1 * (x - y) - 2 * c1**2 * (x**2 + x * y + y**2)),
+        fbar=(c0 + c1 * (x - y)) * (3 * c0 * (x - y) + 2 * c1 * (x**2 - x * y + y**2)),
     )

--- a/ramanujan/cmf/known_cmfs/known_cmfs.py
+++ b/ramanujan/cmf/known_cmfs/known_cmfs.py
@@ -1,5 +1,5 @@
 import sympy as sp
-from sympy.abc import x, y
+from sympy.abc import a, b, c, x, y
 
 from ramanujan import Matrix
 from ramanujan.cmf import CMF
@@ -92,4 +92,23 @@ def cmf3_3():
     return FFbar(
         f=(x + y) * (c0**2 - c0 * c1 * (x - y) - 2 * c1**2 * (x**2 + x * y + y**2)),
         fbar=(c0 + c1 * (x - y)) * (3 * c0 * (x - y) + 2 * c1 * (x**2 - x * y + y**2)),
+    )
+
+
+def hypergeometric_derived_3d():
+    return CMF(
+        matrices={
+            a: Matrix(
+                [[1 + 2 * a, (1 + 2 * a) * (1 + 2 * b)], [1, 5 + 4 * a + 2 * b + 4 * c]]
+            ),
+            b: Matrix(
+                [[1 + 2 * b, (1 + 2 * a) * (1 + 2 * b)], [1, 5 + 2 * a + 4 * b + 4 * c]]
+            ),
+            c: Matrix(
+                [
+                    [-1 - 2 * c, (1 + 2 * a) * (1 + 2 * b)],
+                    [1, 3 + 2 * a + 2 * b + 2 * c],
+                ]
+            ),
+        }
     )

--- a/ramanujan/cmf/known_cmfs/known_cmfs_test.py
+++ b/ramanujan/cmf/known_cmfs/known_cmfs_test.py
@@ -33,7 +33,7 @@ def test_cmf_zeta3():
 def test_apery():
     mp.mp.dps = 10000
     cmf = known_cmfs.zeta3()
-    pcf = cmf.as_pcf({x: 1, y: 1}, {x: 1, y: 1}).pcf
+    pcf = cmf.as_pcf({x: 1, y: 1}).pcf
     # This is Apery's PCF
     assert pcf == PCF(34 * n**3 + 51 * n**2 + 27 * n + 5, -(n**6))
 

--- a/ramanujan/cmf/known_cmfs/known_cmfs_test.py
+++ b/ramanujan/cmf/known_cmfs/known_cmfs_test.py
@@ -68,3 +68,4 @@ def test_all_cmfs():
     known_cmfs.cmf3_1()
     known_cmfs.cmf3_2()
     known_cmfs.cmf3_3()
+    known_cmfs.hypergeometric_derived_3d()

--- a/ramanujan/matrix.py
+++ b/ramanujan/matrix.py
@@ -17,6 +17,9 @@ class Matrix(sp.Matrix):
     https://docs.sympy.org/latest/modules/matrices/matrices.html
     """
 
+    def __eq__(self, other: Matrix):
+        return all(sp.simplify(cell) == 0 for cell in self - other)
+
     def __call__(self, *args, **kwargs):
         """
         Substitutes variables in the matrix, in a more math-like syntax.


### PR DESCRIPTION
Support multi-dimensional CMFs.

1. Change the internal CMF structure to hold a dict of symbol->matrix instead of hardcoded Mx and My.
2. Support symbol querying of a CMF.
3. Generalize all CMF logic (for example, `CMF.trajectory_matrix`)
4. Add the new hypergeometric-derived 3d CMF discovered by Shachar